### PR TITLE
Changed the way read_qr function is called in tasks.py

### DIFF
--- a/apps/digitalization/tasks.py
+++ b/apps/digitalization/tasks.py
@@ -201,10 +201,7 @@ def scheduled_postprocess(input_folder: str, temp_folder: str, log_folder: str):
                     done = False
                     log_object.found_images += 1
                     logging.info("Reading QR...")
-                    qr = read_qr(filename,
-                                 WIDTH_CROP, HEIGHT_CROP,
-                                 MARGIN, PARAMETERS[session_folder.get_institution()]["CORNER"],
-                                 process_logger)
+                    qr = read_qr(filename, process_logger)
                     if qr is not None:
                         json_qr = json.loads(qr)
                         code_voucher = json_qr['code']


### PR DESCRIPTION
The way read_qr is called in tasks.py is changed, because now the function only receives the name of the image file and the logger as parameters, and is independent of default values ​​such as WIDHT CROP, HEIGHT CROP, etc. In this way, you go from needing 6 arguments to only 2.
